### PR TITLE
(hopefully) fixes Shynixn/MCCoroutine#82

### DIFF
--- a/mccoroutine-bukkit-core/src/main/java/com/github/shynixn/mccoroutine/bukkit/dispatcher/AsyncCoroutineDispatcher.kt
+++ b/mccoroutine-bukkit-core/src/main/java/com/github/shynixn/mccoroutine/bukkit/dispatcher/AsyncCoroutineDispatcher.kt
@@ -19,6 +19,9 @@ internal open class AsyncCoroutineDispatcher(
      * may leave the coroutines that use this dispatcher in the inconsistent and hard to debug state.
      */
     override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+        if (!plugin.isEnabled) {
+            return false
+        }
         wakeUpBlockService.ensureWakeup()
         return plugin.server.isPrimaryThread
     }
@@ -27,10 +30,6 @@ internal open class AsyncCoroutineDispatcher(
      * Handles dispatching the coroutine on the correct thread.
      */
     override fun dispatch(context: CoroutineContext, block: Runnable) {
-        if (!plugin.isEnabled) {
-            return
-        }
-
         plugin.server.scheduler.runTaskAsynchronously(plugin, block)
     }
 }

--- a/mccoroutine-bukkit-core/src/main/java/com/github/shynixn/mccoroutine/bukkit/dispatcher/MinecraftCoroutineDispatcher.kt
+++ b/mccoroutine-bukkit-core/src/main/java/com/github/shynixn/mccoroutine/bukkit/dispatcher/MinecraftCoroutineDispatcher.kt
@@ -20,6 +20,9 @@ internal open class MinecraftCoroutineDispatcher(
      * may leave the coroutines that use this dispatcher in the inconsistent and hard to debug state.
      */
     override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+        if (!plugin.isEnabled) {
+            return false
+        }
         wakeUpBlockService.ensureWakeup()
         return !plugin.server.isPrimaryThread
     }
@@ -28,10 +31,6 @@ internal open class MinecraftCoroutineDispatcher(
      * Handles dispatching the coroutine on the correct thread.
      */
     override fun dispatch(context: CoroutineContext, block: Runnable) {
-        if (!plugin.isEnabled) {
-            return
-        }
-
         val timedRunnable = context[CoroutineTimings.Key]
 
         if (timedRunnable == null) {


### PR DESCRIPTION
I was not sure if `wakeUpBlockService.ensureWakeup()` can safely be called if the plugin is not enabled, so I implemented it like this. If that's not how you expected it, please comment and I will change it.

Then I would implement it like:
```java
wakeUpBlockService.ensureWakeup()
return plugin.isEnabled && plugin.server.isPrimaryThread
``` 