### PR TITLE
feat(fabric-api): make MCCoroutineExceptionEvent to be SAM

### DIFF
--- a/mccoroutine-fabric-api/src/main/java/com/github/shynixn/mccoroutine/fabric/MCCoroutineExceptionEvent.kt
+++ b/mccoroutine-fabric-api/src/main/java/com/github/shynixn/mccoroutine/fabric/MCCoroutineExceptionEvent.kt
@@ -8,7 +8,7 @@ import net.fabricmc.fabric.api.event.EventFactory
  * Cancelling this exception causes the error to not get logged and offers to possibility for custom logging.
  */
 @FunctionalInterface
-interface MCCoroutineExceptionEvent {
+fun interface MCCoroutineExceptionEvent {
     companion object {
         val EVENT: Event<MCCoroutineExceptionEvent> =
             EventFactory.createArrayBacked(MCCoroutineExceptionEvent::class.java) { listeners ->


### PR DESCRIPTION
make MCCoroutineExceptionEvent to be a functional interface for kotlin
Related to #118 